### PR TITLE
Various Inspections cleanup from android studio

### DIFF
--- a/app/src/main/java/com/circle/android/api/OkHttp3Stack.java
+++ b/app/src/main/java/com/circle/android/api/OkHttp3Stack.java
@@ -68,7 +68,7 @@ public class OkHttp3Stack implements HttpStack {
         this.mClient = okHttpClient;
     }
 
-    private static HttpEntity entityFromOkHttpResponse(Response r) throws IOException {
+    private static HttpEntity entityFromOkHttpResponse(Response r) {
         BasicHttpEntity entity = new BasicHttpEntity();
         ResponseBody body = r.body();
 
@@ -84,7 +84,7 @@ public class OkHttp3Stack implements HttpStack {
 
     @SuppressWarnings("deprecation")
     private static void setConnectionParametersForRequest(okhttp3.Request.Builder builder, com.android.volley.Request<?> request)
-            throws IOException, AuthFailureError {
+            throws AuthFailureError {
         switch (request.getMethod()) {
             case Request.Method.DEPRECATED_GET_OR_POST:
                 // Ensure backwards compatibility.  Volley assumes a request with a null body is a GET.

--- a/app/src/main/java/com/flipkart/okhttpstatsdemo/MainActivity.java
+++ b/app/src/main/java/com/flipkart/okhttpstatsdemo/MainActivity.java
@@ -62,7 +62,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         onResponseReceived = new OnResponseReceived();
@@ -81,10 +81,10 @@ public class MainActivity extends AppCompatActivity {
 
         okHttp3Stack = new OkHttp3Stack(okHttpClient);
 
-        final NetworkImageView networkImageView = (NetworkImageView) findViewById(R.id.img);
+        final NetworkImageView networkImageView = findViewById(R.id.img);
         assert networkImageView != null;
 
-        FloatingActionButton fab = (FloatingActionButton) findViewById(R.id.fab);
+        FloatingActionButton fab = findViewById(R.id.fab);
         assert fab != null;
         fab.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/test/java/com/flipkart/okhttpstatsdemo/ExampleUnitTest.java
+++ b/app/src/test/java/com/flipkart/okhttpstatsdemo/ExampleUnitTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
     @Test
-    public void addition_isCorrect() throws Exception {
+    public void addition_isCorrect() {
         assertEquals(4, 2 + 2);
     }
 }

--- a/library/src/main/java/com/flipkart/okhttpstats/NetworkInterceptor.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/NetworkInterceptor.java
@@ -42,7 +42,7 @@ public final class NetworkInterceptor implements Interceptor {
 
     private final NetworkInterpreter mInterpreter;
     private final AtomicInteger mNextRequestId = new AtomicInteger(1);
-    private boolean mEnabled = true;
+    private final boolean mEnabled;
 
     NetworkInterceptor(Builder builder) {
         mEnabled = builder.mEnabled;

--- a/library/src/main/java/com/flipkart/okhttpstats/handler/ForwardingResponse.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/handler/ForwardingResponse.java
@@ -30,7 +30,7 @@ import com.flipkart.okhttpstats.toolbox.HttpStatusCode;
 
 public class ForwardingResponse implements OnResponseListener {
 
-    private OnStatusCodeAwareResponseListener mOnStatusCodeAwareResponseListener;
+    private final OnStatusCodeAwareResponseListener mOnStatusCodeAwareResponseListener;
 
 
     public ForwardingResponse(OnStatusCodeAwareResponseListener onStatusCodeAwareResponseListener) {

--- a/library/src/main/java/com/flipkart/okhttpstats/handler/PersistentStatsHandler.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/handler/PersistentStatsHandler.java
@@ -58,13 +58,13 @@ public class PersistentStatsHandler implements NetworkRequestStatsHandler {
     private static final String MOBILE_NETWORK = "mobile";
     private static final String UNKNOWN_NETWORK = "unknown";
     private final PreferenceManager mPreferenceManager;
-    Set<OnResponseListener> mOnResponseListeners = new HashSet<>();
+    final Set<OnResponseListener> mOnResponseListeners = new HashSet<>();
     private int mResponseCount = 0;
     private int MAX_SIZE;
-    private WifiManager mWifiManager;
-    private NetworkStat mNetworkStat;
-    private float mCurrentAvgSpeed = 0;
-    private ConnectivityManager mConnectivityManager;
+    private final WifiManager mWifiManager;
+    private final NetworkStat mNetworkStat;
+    private float mCurrentAvgSpeed;
+    private final ConnectivityManager mConnectivityManager;
 
     public PersistentStatsHandler(Context context) {
         this.mPreferenceManager = new PreferenceManager(context);

--- a/library/src/main/java/com/flipkart/okhttpstats/interpreter/DefaultInterpreter.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/interpreter/DefaultInterpreter.java
@@ -51,14 +51,14 @@ import okio.Okio;
 public class DefaultInterpreter implements NetworkInterpreter {
     private static final String HOST_NAME = "HOST";
     private static final String CONTENT_LENGTH = "Content-Length";
-    NetworkEventReporter mEventReporter;
+    final NetworkEventReporter mEventReporter;
 
     public DefaultInterpreter(NetworkEventReporter mEventReporter) {
         this.mEventReporter = mEventReporter;
     }
 
     @Override
-    public Response interpretResponseStream(int requestId, NetworkInterceptor.TimeInfo timeInfo, Request request, Response response) throws IOException {
+    public Response interpretResponseStream(int requestId, NetworkInterceptor.TimeInfo timeInfo, Request request, Response response) {
         ResponseBody responseBody = response.body();
 
         final OkHttpInspectorRequest okHttpInspectorRequest = new OkHttpInspectorRequest(requestId, request.url().url(), request.method(), Utils.contentLength(request.headers()), request.url().host(), request.body());
@@ -162,12 +162,12 @@ public class DefaultInterpreter implements NetworkInterpreter {
      * Implementation of {@link NetworkEventReporter.InspectorResponse}
      */
     static class OkHttpInspectorResponse implements NetworkEventReporter.InspectorResponse {
-        int mRequestId;
-        long mStartTime;
-        long mEndTime;
-        int mStatusCode;
+        final int mRequestId;
+        final long mStartTime;
+        final long mEndTime;
+        final int mStatusCode;
         long mResponseSize;
-        @Nullable
+        @Nullable final
         ResponseBody responseBody;
 
         OkHttpInspectorResponse(int requestId, int statusCode, long responseSize, long startTime, long endTime, @Nullable ResponseBody responseBody) {

--- a/library/src/main/java/com/flipkart/okhttpstats/interpreter/NetworkInterpreter.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/interpreter/NetworkInterpreter.java
@@ -46,7 +46,7 @@ public interface NetworkInterpreter {
      * @return Response
      * @throws IOException
      */
-    Response interpretResponseStream(int requestId, NetworkInterceptor.TimeInfo timeInfo, Request request, Response response) throws IOException;
+    Response interpretResponseStream(int requestId, NetworkInterceptor.TimeInfo timeInfo, Request request, Response response);
 
     /**
      * Interpre the error received

--- a/library/src/main/java/com/flipkart/okhttpstats/reporter/NetworkEventReporterImpl.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/reporter/NetworkEventReporterImpl.java
@@ -44,7 +44,7 @@ import okhttp3.ResponseBody;
  */
 public class NetworkEventReporterImpl implements NetworkEventReporter {
 
-    private NetworkRequestStatsHandler mNetworkRequestStatsHandler;
+    private final NetworkRequestStatsHandler mNetworkRequestStatsHandler;
 
     public NetworkEventReporterImpl(NetworkRequestStatsHandler networkRequestStatsHandler) {
         this.mNetworkRequestStatsHandler = networkRequestStatsHandler;

--- a/library/src/main/java/com/flipkart/okhttpstats/response/CountingInputStream.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/response/CountingInputStream.java
@@ -46,7 +46,7 @@ public class CountingInputStream extends FilterInputStream {
     }
 
     @Override
-    public int read() throws IOException {
+    public int read() {
         try {
             int result = checkEOF(in.read());
             if (result != -1) {
@@ -65,7 +65,7 @@ public class CountingInputStream extends FilterInputStream {
     }
 
     @Override
-    public int read(@NonNull byte[] b, int off, int len) throws IOException {
+    public int read(@NonNull byte[] b, int off, int len) {
         try {
             int result = checkEOF(in.read(b, off, len));
             if (result != -1) {
@@ -84,7 +84,7 @@ public class CountingInputStream extends FilterInputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public void reset() {
         throw new UnsupportedOperationException("Mark not supported");
     }
 }

--- a/library/src/main/java/com/flipkart/okhttpstats/toolbox/NetworkStat.java
+++ b/library/src/main/java/com/flipkart/okhttpstats/toolbox/NetworkStat.java
@@ -35,7 +35,7 @@ public final class NetworkStat {
 
     private static final int MAX_QUEUE_SIZE = 5;
     private double mPeakSpeed = 0;
-    private Queue<RequestStats> mRequestStatQueue;
+    private final Queue<RequestStats> mRequestStatQueue;
     private double mTotalSize = 0;
     public double mCurrentAvgSpeed = 0;
 

--- a/library/src/test/java/com/flipkart/okhttpstats/handler/ForwardingResponseTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/handler/ForwardingResponseTest.java
@@ -26,7 +26,7 @@ public class ForwardingResponseTest {
      * @throws Exception
      */
     @Test
-    public void testOnResponseServerSuccessCalledFor2XX3XX() throws Exception {
+    public void testOnResponseServerSuccessCalledFor2XX3XX() {
         OnStatusCodeAwareResponseListener onStatusCodeAwareResponseListener = mock(OnStatusCodeAwareResponseListener.class);
         ForwardingResponse forwardingResponse = new ForwardingResponse(onStatusCodeAwareResponseListener);
 
@@ -80,7 +80,7 @@ public class ForwardingResponseTest {
      * @throws Exception
      */
     @Test
-    public void testOnResponseServerErrorCalledFor4XX5XX() throws Exception {
+    public void testOnResponseServerErrorCalledFor4XX5XX() {
         OnStatusCodeAwareResponseListener onStatusCodeAwareResponseListener = mock(OnStatusCodeAwareResponseListener.class);
         ForwardingResponse forwardingResponse = new ForwardingResponse(onStatusCodeAwareResponseListener);
 
@@ -134,7 +134,7 @@ public class ForwardingResponseTest {
      * @throws Exception
      */
     @Test
-    public void testOnResponseNetworkErrorCalledForNetworkErrors() throws Exception {
+    public void testOnResponseNetworkErrorCalledForNetworkErrors() {
         OnStatusCodeAwareResponseListener onStatusCodeAwareResponseListener = mock(OnStatusCodeAwareResponseListener.class);
         ForwardingResponse forwardingResponse = new ForwardingResponse(onStatusCodeAwareResponseListener);
 

--- a/library/src/test/java/com/flipkart/okhttpstats/handler/PersistentStatsHandlerTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/handler/PersistentStatsHandlerTest.java
@@ -3,11 +3,11 @@ package com.flipkart.okhttpstats.handler;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-
 import com.flipkart.okhttpstats.BuildConfig;
 import com.flipkart.okhttpstats.model.RequestStats;
 import com.flipkart.okhttpstats.toolbox.PreferenceManager;
-
+import java.io.IOException;
+import java.net.SocketTimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,9 +18,6 @@ import org.robolectric.internal.ShadowExtractor;
 import org.robolectric.shadows.ShadowConnectivityManager;
 import org.robolectric.shadows.ShadowNetworkInfo;
 
-import java.io.IOException;
-import java.net.SocketTimeoutException;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyString;
@@ -29,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by anirudh.r on 13/05/16 at 12:28 AM.
@@ -45,7 +41,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testAddListener() throws Exception {
+    public void testAddListener() {
         ConnectivityManager connectivityManager = (ConnectivityManager) RuntimeEnvironment.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager shadowConnectivityManager = (ShadowConnectivityManager) ShadowExtractor.extract(connectivityManager);
         ShadowNetworkInfo shadowOfActiveNetworkInfo = (ShadowNetworkInfo) ShadowExtractor.extract(connectivityManager.getActiveNetworkInfo());
@@ -68,7 +64,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testRemoveListener() throws Exception {
+    public void testRemoveListener() {
         OnResponseListener onResponseListener = mock(OnResponseListener.class);
 
         PersistentStatsHandler persistentStatsHandler = new PersistentStatsHandler(RuntimeEnvironment.application);
@@ -88,7 +84,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testOnResponseReceived() throws Exception {
+    public void testOnResponseReceived() {
         OnResponseListener onResponseListener = mock(OnResponseListener.class);
         OnResponseListener onResponseListener1 = mock(OnResponseListener.class);
 
@@ -124,7 +120,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testOnHttpExchangeError() throws Exception {
+    public void testOnHttpExchangeError() {
         OnResponseListener onResponseListener = mock(OnResponseListener.class);
         OnResponseListener onResponseListener1 = mock(OnResponseListener.class);
 
@@ -158,7 +154,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testOnInputStreamError() throws Exception {
+    public void testOnInputStreamError() {
         OnResponseListener onResponseListener = mock(OnResponseListener.class);
         OnResponseListener onResponseListener1 = mock(OnResponseListener.class);
 
@@ -187,7 +183,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testGetWifiSSID() throws Exception {
+    public void testGetWifiSSID() {
         ConnectivityManager connectivityManager = (ConnectivityManager) RuntimeEnvironment.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager shadowConnectivityManager = (ShadowConnectivityManager) ShadowExtractor.extract(connectivityManager);
         ShadowNetworkInfo shadowOfActiveNetworkInfo = (ShadowNetworkInfo) ShadowExtractor.extract(connectivityManager.getActiveNetworkInfo());
@@ -205,7 +201,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testGetNetworkKey() throws Exception {
+    public void testGetNetworkKey() {
         ConnectivityManager connectivityManager = (ConnectivityManager) RuntimeEnvironment.application.getSystemService(Context.CONNECTIVITY_SERVICE);
         ShadowConnectivityManager shadowConnectivityManager = (ShadowConnectivityManager) ShadowExtractor.extract(connectivityManager);
         shadowConnectivityManager.setNetworkInfo(ConnectivityManager.TYPE_WIFI, connectivityManager.getActiveNetworkInfo());
@@ -221,7 +217,7 @@ public class PersistentStatsHandlerTest {
      * @throws Exception
      */
     @Test
-    public void testSaveToSharedPreferenceCalled() throws Exception {
+    public void testSaveToSharedPreferenceCalled() {
         PreferenceManager preferenceManager = mock(PreferenceManager.class);
 
         PersistentStatsHandler persistentStatsHandler = new PersistentStatsHandler(RuntimeEnvironment.application, preferenceManager);

--- a/library/src/test/java/com/flipkart/okhttpstats/handler/PreferenceManagerTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/handler/PreferenceManagerTest.java
@@ -30,7 +30,7 @@ public class PreferenceManagerTest {
      * @throws Exception
      */
     @Test
-    public void testSharedPreference() throws Exception {
+    public void testSharedPreference() {
 
         PreferenceManager preferenceManager = new PreferenceManager(RuntimeEnvironment.application);
 
@@ -50,7 +50,7 @@ public class PreferenceManagerTest {
      * @throws Exception
      */
     @Test
-    public void testSharedPrefForDiffNetwork() throws Exception {
+    public void testSharedPrefForDiffNetwork() {
         PreferenceManager preferenceManager = new PreferenceManager(RuntimeEnvironment.application);
         PersistentStatsHandler persistentStatsHandler = new PersistentStatsHandler(RuntimeEnvironment.application);
 

--- a/library/src/test/java/com/flipkart/okhttpstats/interpreter/DefaultInterpreterTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/interpreter/DefaultInterpreterTest.java
@@ -68,7 +68,7 @@ public class DefaultInterpreterTest {
      * @throws Exception
      */
     @Test
-    public void testOnHttpExchangeErrorGetsCalled() throws Exception {
+    public void testOnHttpExchangeErrorGetsCalled() {
         NetworkEventReporter networkEventReporter = mock(NetworkEventReporter.class);
         DefaultInterpreter defaultInterpreter = new DefaultInterpreter(networkEventReporter);
 
@@ -92,7 +92,7 @@ public class DefaultInterpreterTest {
      * Tests setter and getter of {@link com.flipkart.okhttpstats.interpreter.DefaultInterpreter.OkHttpInspectorRequest}
      */
     @Test
-    public void testOkHttpInspectorRequest() throws Exception {
+    public void testOkHttpInspectorRequest() {
 
         String requestText = "Test Request";
 
@@ -121,7 +121,7 @@ public class DefaultInterpreterTest {
      * Tests setter and getter of {@link com.flipkart.okhttpstats.interpreter.DefaultInterpreter.OkHttpInspectorResponse}
      */
     @Test
-    public void testOkHttpInspectorResponse() throws Exception {
+    public void testOkHttpInspectorResponse() {
 
         ResponseBody responseBody = mock(ResponseBody.class);
         DefaultInterpreter.OkHttpInspectorResponse okHttpInspectorResponse = new DefaultInterpreter.OkHttpInspectorResponse(1, 200, 20, 2, 3, responseBody);

--- a/library/src/test/java/com/flipkart/okhttpstats/interpreter/NetworkInterceptorTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/interpreter/NetworkInterceptorTest.java
@@ -60,7 +60,7 @@ public class NetworkInterceptorTest {
      * @throws Exception
      */
     @Test(expected = IllegalStateException.class)
-    public void testIfExceptionThrownIfInterpreterNull() throws Exception {
+    public void testIfExceptionThrownIfInterpreterNull() {
         new NetworkInterceptor.Builder()
                 .setEnabled(true)
                 .setNetworkInterpreter(null)
@@ -304,7 +304,7 @@ public class NetworkInterceptorTest {
      * Tests setter and getter of {@link com.flipkart.okhttpstats.interpreter.DefaultInterpreter.OkHttpInspectorRequest}
      */
     @Test
-    public void testOkHttpInspectorRequest() throws Exception {
+    public void testOkHttpInspectorRequest() {
 
         Uri requestUri = Uri.parse("http://www.flipkart.com");
         String requestText = "Test Request";
@@ -334,7 +334,7 @@ public class NetworkInterceptorTest {
      * Tests setter and getter of {@link com.flipkart.okhttpstats.interpreter.DefaultInterpreter.OkHttpInspectorResponse}
      */
     @Test
-    public void testOkHttpInspectorResponse() throws Exception {
+    public void testOkHttpInspectorResponse() {
 
         DefaultInterpreter.OkHttpInspectorResponse okHttpInspectorResponse = new DefaultInterpreter.OkHttpInspectorResponse(1, 200, 20, 2, 3, mock(ResponseBody.class));
 
@@ -369,7 +369,7 @@ public class NetworkInterceptorTest {
         }
 
         @Override
-        public Response proceed(Request request) throws IOException {
+        public Response proceed(Request request) {
             if (mRequest != request) {
                 throw new IllegalArgumentException(
                         "Expected " + System.identityHashCode(mRequest) +

--- a/library/src/test/java/com/flipkart/okhttpstats/model/RequestStatsTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/model/RequestStatsTest.java
@@ -26,8 +26,6 @@ public class RequestStatsTest {
     public void testDataIntegrity() throws MalformedURLException {
         RequestStats requestStats = new RequestStats(1);
 
-        NetworkInfo networkInfo = mock(NetworkInfo.class);
-
         requestStats.url = new URL("http://www.flipkart.com");
         requestStats.requestSize = 20;
         requestStats.methodType = "POST";

--- a/library/src/test/java/com/flipkart/okhttpstats/reporter/NetworkEventReporterTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/reporter/NetworkEventReporterTest.java
@@ -36,11 +36,10 @@ public class NetworkEventReporterTest {
      * @throws Exception
      */
     @Test
-    public void testResponseReceived() throws Exception {
+    public void testResponseReceived() {
         HandlerThread handlerThread = new HandlerThread("back");
         handlerThread.start();
         Looper looper = handlerThread.getLooper();
-        Handler handler = new Handler(looper);
         ShadowLooper shadowLooper = (ShadowLooper) ShadowExtractor.extract(looper);
 
         NetworkRequestStatsHandler networkRequestStatsHandler = mock(NetworkRequestStatsHandler.class);
@@ -63,11 +62,10 @@ public class NetworkEventReporterTest {
      * @throws Exception
      */
     @Test
-    public void testHttpExchangeError() throws Exception {
+    public void testHttpExchangeError() {
         HandlerThread handlerThread = new HandlerThread("back");
         handlerThread.start();
         Looper looper = handlerThread.getLooper();
-        Handler handler = new Handler(looper);
         ShadowLooper shadowLooper = (ShadowLooper) ShadowExtractor.extract(looper);
 
         NetworkRequestStatsHandler networkRequestStatsHandler = mock(NetworkRequestStatsHandler.class);
@@ -90,11 +88,10 @@ public class NetworkEventReporterTest {
      * @throws Exception
      */
     @Test
-    public void testResponseInputStreamError() throws Exception {
+    public void testResponseInputStreamError() {
         HandlerThread handlerThread = new HandlerThread("back");
         handlerThread.start();
         Looper looper = handlerThread.getLooper();
-        Handler handler = new Handler(looper);
         ShadowLooper shadowLooper = (ShadowLooper) ShadowExtractor.extract(looper);
 
         NetworkRequestStatsHandler networkRequestStatsHandler = mock(NetworkRequestStatsHandler.class);

--- a/library/src/test/java/com/flipkart/okhttpstats/response/CountingInputStreamTest.java
+++ b/library/src/test/java/com/flipkart/okhttpstats/response/CountingInputStreamTest.java
@@ -68,7 +68,7 @@ public class CountingInputStreamTest {
      * @throws IOException
      */
     @Test
-    public void testOnMark() throws IOException {
+    public void testOnMark() {
         ResponseHandler responseHandler = mock(ResponseHandler.class);
         String myString = "Hello! How are you";
         InputStream is = new ByteArrayInputStream(myString.getBytes());


### PR DESCRIPTION
Clean a bunch of inspections from IDE.
1. Removed redundant throws.
2. Removed redundant casts.
3. Make relevant fields final.
4. Remove unused fields and local variables.

@anirudhramanan there are few more inspection issues but those are far more subjective. Also, any question why is the project an `android-library` instead of `java-library`.
